### PR TITLE
ControlledFragmentAssembler on subscription

### DIFF
--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.0
 Name: aeron_python
-Version: 1.0.0
+Version: 1.0.1
 Summary: Python bindings for Aeron
 Home-page: https://github.com/fairtide/aeron-python
 Author: Fairtide Pte

--- a/samples/basic_publisher.py
+++ b/samples/basic_publisher.py
@@ -3,6 +3,7 @@ from argparse import ArgumentParser, ArgumentError
 from datetime import timedelta
 from time import sleep
 
+import numpy as np
 from aeronpy import Context, BACK_PRESSURED, NOT_CONNECTED, ADMIN_ACTION, PUBLICATION_CLOSED
 
 
@@ -12,30 +13,46 @@ def main():
         parser.add_argument('-p', '--prefix', default=None)
         parser.add_argument('-c', '--channel', default='aeron:udp?endpoint=localhost:40123')
         parser.add_argument('-s', '--stream_id', type=int, default=1)
-        parser.add_argument('-m', '--messages', type=int, default=sys.maxsize)
-        parser.add_argument('-l', '--linger', type=int, default=60*60*1000)
+        parser.add_argument('-m', '--messages', type=int, default=1e5)
+        parser.add_argument('-ms', '--messagesize', type=int, default=250)
+        parser.add_argument('-l', '--linger', type=int, default=60 * 60 * 1000)
 
         args = parser.parse_args()
+
         context = Context(
             aeron_dir=args.prefix,
             resource_linger_timeout=timedelta(milliseconds=args.linger),
             new_publication_handler=lambda *args: print(f'new publication - {args}'))
-
+        import time
+        start = time.time()
         publication = context.add_publication(args.channel, args.stream_id)
-        for i in range(args.messages):
-            result = publication.offer(f'Hallo World! {i}')
-            if result == BACK_PRESSURED:
-                print('Offer failed due to back pressure')
-            elif result == NOT_CONNECTED:
-                print('Offer failed because publisher is not connected to subscriber')
-            elif result == ADMIN_ACTION:
-                print('Offer failed because of an administration action in the system')
-            elif result == PUBLICATION_CLOSED:
-                print('Offer failed publication is closed')
-            else:
-                print('yay!')
+        i = 0
+        while i < args.messages:
+            data = np.random.uniform(size=args.messagesize)
+            data[0] = i
+            data_bytes = data.tobytes()
 
-            sleep(1)
+            while True:
+                result = publication.offer(data_bytes)
+
+                if result >= 0:
+                    i += 1
+                    break
+                else:
+                    if result == BACK_PRESSURED:
+                        print('Offer failed due to back pressure')
+                    elif result == NOT_CONNECTED:
+                        print('Offer failed because publisher is not connected to subscriber')
+                    elif result == ADMIN_ACTION:
+                        print('Offer failed because of an administration action in the system')
+                    elif result == PUBLICATION_CLOSED:
+                        print('Offer failed publication is closed')
+
+                    sleep(.5)
+        end = time.time()
+        print("%d,%d,%.3f" % (args.messages, args.messagesize, end - start))
+        # with open("log.csv", "at") as f:
+        #     f.write("%d,%d,%.3f\n" % (args.messages, args.messagesize, end - start))
 
         return 0
 
@@ -48,4 +65,5 @@ def main():
 
 
 if __name__ == '__main__':
-    exit(main())
+    ret = main()
+    exit(ret)

--- a/samples/basic_subscriber.py
+++ b/samples/basic_subscriber.py
@@ -1,8 +1,13 @@
 import sys
 from argparse import ArgumentParser, ArgumentError
-from time import sleep
 
-from aeronpy import Context
+import aeronpy
+import numpy as np
+
+messages = 0
+count = 0
+
+data_log = np.zeros(int(1e6) + 1, dtype=int)
 
 
 def main():
@@ -13,21 +18,38 @@ def main():
         parser.add_argument('-s', '--stream_id', type=int, default=1)
 
         args = parser.parse_args()
-        context = Context(
+        context = aeronpy.Context(
             aeron_dir=args.prefix,
             new_subscription_handler=lambda *args: print(f'new subscription {args}'),
             available_image_handler=lambda *args: print(f'available image {args}'),
             unavailable_image_handler=lambda *args: print(f'unavailable image {args}'))
 
+        def process_data(data_bytes):
+            global count, messages
+            messages += 1
+
+            data = np.frombuffer(data_bytes, dtype=float)
+            nbytes = len(bytes(data_bytes))
+            count += nbytes
+
+            data_log[int(data[0])] += 1
+
+            if messages % 100000 == 0:
+                print("Messages %d total bytes %d" % (messages, count))
+
         subscription = context.add_subscription(args.channel, args.stream_id)
         while True:
-            fragments_read = subscription.poll(lambda data: print(bytes(data)))
+            fragments_read = subscription.poll(process_data)
+
             if fragments_read == 0:
                 eos_count = subscription.poll_eos(lambda *args: print(f'end of stream: {args}'))
                 if eos_count > 0:
                     break
 
-            sleep(0.1)
+        print("Messages %d total bytes %d, bytes per message %f" % (messages, count, count / messages))
+        print("Printing the ids of the messages with a received count !=1"
+              ", the index should be starting at number of messages")
+        print(np.where(data_log != 1)[0][:5])
 
         return 0
 
@@ -40,4 +62,8 @@ def main():
 
 
 if __name__ == '__main__':
-    exit(main())
+    # input("Press Enter to continue...")
+
+    main_return_code = main()
+
+    exit(main_return_code)

--- a/sources/package/aeronpy/_subscription.hpp
+++ b/sources/package/aeronpy/_subscription.hpp
@@ -22,7 +22,8 @@
 #include <memory>
 #include <string>
 #include <vector>
-
+#include <ControlledFragmentAssembler.h>
+#include <pybind11/pytypes.h>
 
 /**
  * @brief Represents an interop proxy for an Aeron subscription.
@@ -91,8 +92,11 @@ public:
     std::string __str__() const;
 
 private:
-    bool is_complete_poll_handler(pybind11::function& handler);
-
     std::shared_ptr<aeron::Subscription> aeron_subscription_;
 
+    pybind11::function py_func_handler;
+
+    std::shared_ptr<aeron::ControlledFragmentAssembler> fragmentAssembler_ = nullptr;
+
+    void init_fragment_assembler();
 };

--- a/start_aeron_driver.sh
+++ b/start_aeron_driver.sh
@@ -1,1 +1,3 @@
+wget -O aeron-all-1.11.2.jar -c https://bintray.com/lukaszlaszko/aeron/download_file?file_path=aeron-all-1.11.2.jar
+
 java -cp aeron-all-1.11.2.jar io.aeron.driver.MediaDriver

--- a/start_aeron_driver.sh
+++ b/start_aeron_driver.sh
@@ -1,0 +1,1 @@
+java -cp aeron-all-1.11.2.jar io.aeron.driver.MediaDriver


### PR DESCRIPTION
On subscription, if passing messages larger than 1k, the current Python implementation doesn't handle split messages.

I have added the ControlledFragmentAssembler which is used in C++ and Java, to handle reconstruction of the message.

Removed the code to check the python method, since the session id is already known in Python and the other id makes sense for ControllerFragmentAssembler. Users who would consider using 1 single handler for multiple subscriptions can create multiple handlers.